### PR TITLE
OpenAPI Definition for thirdparty-api-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
 # Changelog: [mojaloop/thirdparty-api-adapter](https://github.com/mojaloop/thirdparty-api-adapter)
+### 10.4.1 (2020-06-22)
+
+
+### Features
+
+* **thirdparty-api.yaml:**  OpenAPI specification for thirdparty-api-adapter ([ab274c1](https://github.com/mojaloop/thirdparty-api-adapter/commit/ab274c16ec20f32538425b6e53d4fe727eba1475))
+
 ## 10.4.0 (2020-06-15)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/thirdparty-api-adapter",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/thirdparty-api-adapter",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "The thirdparty-api-adapter service is used to handle HTTP requests from third parties.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/interface/thirdparty-api.yaml
+++ b/src/interface/thirdparty-api.yaml
@@ -1,0 +1,2352 @@
+openapi: 3.0.2
+info:
+  version: "1.0"
+  title: Mojaloop ThirdParty API Adapter
+  description:
+    A Mojaloop API for thirdparty interactions between `PISPs` (Payment Initiation
+    Service Providers) and `DFSPs` (Digital Financial Service Providers)
+  license:
+    name: TBD
+    url: TBD
+servers:
+  - url: '{protocol}://hostname:<port>/'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: https
+paths:
+  /health:
+    get:
+      operationId: HealthGet
+      summary: Get current status of the API
+      description: The HTTP request `GET /health` is used to return the current status of the API.
+      tags:
+        - health
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /metrics:
+    get:
+      operationId: MetricsGet
+      summary: Prometheus metrics endpoint
+      description: The HTTP request `GET /metrics` is used to return metrics for the API.
+      tags:
+        - metrics
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  /parties/{Type}/{ID}:
+    parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: >
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information 
+        regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` 
+        (for example, GET /parties/MSISDN/123456789, or GET /parties/BUSINESS/shoecompany/employee1).
+      summary: Look up party information
+      tags:
+        - parties
+      operationId: PartiesByTypeAndIDGet
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: >
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result 
+        of the Party information lookup.
+      summary: Return party information
+      tags:
+        - parties
+      operationId: PartiesByTypeAndIDPut
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Party information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+            example:
+              party:
+                accounts:
+                  account:
+                    - currency: 'USD'
+                      description: 'savings'
+                      address: 'moja.blue.8f027046-b82a5456-4fa9-838b-70210fcf8136'
+                    - currency: 'USD'
+                      description: 'checkings'
+                      address: 'moja.blue.8f027046-b8236345a-4fa9-838b-70210fcf8137'
+                partyIdInfo:
+                  partyIdType: 'PERSONAL_ID'
+                  partyIdentifier: '16135551212'
+                  partySubIdOrType: 'DRIVING_LICENSE'
+                  fspId: 'dfspa'
+                  extensionList:
+                    extension:
+                      - key: 'Account Type'
+                        value: 'Wallet'
+                merchantClassificationCode: '4321'
+                name: 'Alice Alpaca'
+                personalInfo:
+                  complexName:
+                    firstName: 'Alice'
+                    middleName: 'K'
+                    lastName: 'Alpaca'
+                  dateOfBirth: '1971-12-25'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/error:
+    put:
+      description: >
+        If the server is unable to find Party information of the provided identity, or another processing error occurred, 
+        the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`) is used.
+      summary: Return party information error
+      tags:
+        - parties
+      operationId: PartiesErrorByTypeAndID
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/{SubId}:
+    parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+      #Headers
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: >
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information 
+        regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, GET /parties/MSISDN/123456789, 
+        or GET /parties/BUSINESS/shoecompany/employee1).
+      summary: Look up party information
+      tags:
+        - parties
+      operationId: PartiesSubIdByTypeAndID
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: >
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful 
+        result of the Party information lookup.
+      summary: Return party information
+      tags:
+        - parties
+      operationId: PartiesSubIdByTypeAndIDPut
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Party information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+            example:
+              party:
+                accounts:
+                  account:
+                    - currency: 'USD'
+                      description: 'savings'
+                      address: 'moja.blue.8f027046-b82a5456-4fa9-838b-70210fcf8136'
+                    - currency: 'USD'
+                      description: 'checkings'
+                      address: 'moja.blue.8f027046-b8236345a-4fa9-838b-70210fcf8137'
+                partyIdInfo:
+                  partyIdType: 'PERSONAL_ID'
+                  partyIdentifier: '16135551212'
+                  partySubIdOrType: 'DRIVING_LICENSE'
+                  fspId: 'dfspa'
+                  extensionList:
+                    extension:
+                      - key: 'Account Type'
+                        value: 'Wallet'
+                merchantClassificationCode: '4321'
+                name: 'Justin Trudeau'
+                personalInfo:
+                  complexName:
+                    firstName: 'Justin'
+                    middleName: 'Pierre'
+                    lastName: 'Trudeau'
+                  dateOfBirth: '1971-12-25'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/{SubId}/error:
+    put:
+      description: >
+        If the server is unable to find Party information of the provided identity, or another processing error occurred, 
+        the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubId}/error`) is used.
+      summary: Return party information error
+      tags:
+        - parties
+      operationId: PartiesSubIdErrorByTypeAndID
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/SubId'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  /consentRequests:
+    post:
+      description: |
+        The HTTP request `POST /consentRequests` is used to create a consent request. 
+
+        - Called by a PISP to start the process of establishing consent between three parties(`PISP, DFSP and User(DFSP customer)`).
+      summary: CreateConsentRequest
+      tags:
+        - consentRequest
+      operationId: CreateConsentRequest
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: CreateConsentRequest
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentRequest'
+            example:
+              id: '456'
+              initiatorId: 'pispa'
+              accountIds:
+                - 'dfspa.alice.1234'
+                - 'dfspa.alice.5678'
+              authChannels:
+                - 'Web'
+                - 'OTP'
+              scopes:
+                - 'accounts.getBalance'
+                - 'accounts.transfer'
+              callbackUri: 'pisp-app://callback...'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /consentRequests/{ID}:
+    put:
+      description: |
+        The HTTP request `PUT /consentRequests/{ID}` is used to update a specified consent request.
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /consentRequests`.
+        
+        - Called by a PISP to add the authToken parameter
+        
+        - Called by a DFSP to include the authorizationUri
+      summary: UpdateConsentRequest
+      tags:
+        - consentRequest
+      operationId: UpdateConsentRequest
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: UpdateConsentRequest.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentRequest'
+            example:
+              initiatorId: 'pispa'
+              accountIds:
+                - 'dfspa.alice.1234'
+                - 'dfspa.alice.5678'
+              authChannels:
+                - 'WEB'
+              scopes:
+                - 'accounts.getBalance'
+                - 'accounts.transfer'
+              callbackUri: 'pisp-app://callback...'
+              authorizationUri: 'dfspa.com/authorize?consentRequestId=456'
+              authToken: '000111'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /consentRequests/{ID}/error:
+    put:
+      description: >
+        If the server is unable to find the consent request, or another processing error occurs, 
+        the error callback `PUT /consentRequests/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` 
+        that was used in the `POST /consentRequests`.
+      summary: UpdateConsentRequestError
+      tags:
+        - consentRequest
+      operationId: UpdateConsentRequestError
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  /consents:
+    post:
+      description: |
+        The HTTP request `POST /consents` is used to create a consent object. 
+        
+        - Called by `DFSP` after the succesful creation and validation of a consentRequest.
+      summary: CreateConsent
+      tags:
+        - consent
+      operationId: CreateConsent
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: CreateConsent
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Consent'
+            example:
+              id: '123'
+              requestId: '456'
+              initiatorId: 'pispa'
+              participantId: 'dfspa'
+              scopes:
+                - scope: 'account.balanceInquiry'
+                  accountId: 'dfspa.alice.1234'
+                - scope: 'account.sendTransfer'
+                  accountId: 'dfspa.alice.1234'
+                - scope: 'account.sendTransfer'
+                  accountId: 'dfspa.alice.5678'
+              credential: null
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /consents/{ID}:
+    parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: >
+        The HTTP request `GET /consents/{ID}` is used to get information regarding a consent object created or requested earlier. 
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /consents`.
+      summary: GetConsent
+      tags:
+        - consent
+      operationId: GetConsent
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: |
+        The HTTP request `PUT /consents/{ID}` is used to update a specified consent object. 
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /consents`.
+
+        - Called by a `auth-service` to add the credential details
+        
+        - Called by a `PISP` to add a signature of the challenge
+      summary: UpdateConsent
+      tags:
+        - consent
+      operationId: UpdateConsent
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: UpdateConsent.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Consent'
+            example:
+              requestId: '456'
+              initiatorId: 'dfspa'
+              participantId: 'pispa'
+              scopes:
+                - scope: 'account.balanceInquiry'
+                  accountId: 'dfspa.alice.1234'
+                - scope: 'account.sendTransfer'
+                  accountId: 'dfspa.alice.1234'
+                - scope: 'account.sendTransfer'
+                  accountId: 'dfspa.alice.5678'
+              credential:
+                id: '5678'
+                credentialType: 'FIDO'
+                credentialStatus: 'ACTIVE'
+                challenge:
+                  payload: 'base64(...)'
+                  signature: 'base64(...)'
+                payload: 'base64(...)'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /consents/{ID}/createCredential:
+    post:
+      description: |
+        The HTTP request `POST /consents/{ID}/createCredential` is used to create a credential for the given Consent object. 
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /consents`.
+
+        - Called by a `PISP` to request a challenge from the `auth-service`, which will be returned to the PISP via `PUT /consents/{ID}`
+      summary: CreateCredential
+      tags:
+        - consent
+      operationId: CreateCredential
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: CreateCredential
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCredential'
+            example:
+              type: 'FIDO'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  #thirdPartyRequests
+  /thirdPartyRequests/transactions:
+    post:
+      description: |
+        The HTTP request `POST /thirdPartyRequests/transactions` is used to request the creation of a third party transaction.
+
+        - Called by a `PISP` to initiate a third party transaction flow
+      summary: CreateThirdPartyTransactionRequests
+      tags:
+        - thirdPartyRequests
+      operationId: CreateThirdPartyTransactionRequests
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Transaction request to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThirdPartyTransactionRequest'
+            example:
+              transactionRequestId: '8d34f91d-d078-4077-8263-2c047876fcf6'
+              sourceAccountId: 'dfspa.alice.1234'
+              consentId: '111'
+              payee:
+                partyIdInfo:
+                  partyIdType: 'MSISDN'
+                  partyIdentifier: '+44 1234 5678'
+                  fspId: 'dfspb'
+              payer:
+                personalInfo:
+                  complexName:
+                    firstName: 'Alice'
+                    lastName: 'K'
+                partyIdInfo:
+                  partyIdType: 'MSISDN'
+                  partyIdentifier: '+44 8765 4321'
+                  fspId: 'dfspa'
+              amountType: 'SEND'
+              amount:
+                amount: '100'
+                currency: 'USD'
+              transactionType:
+                scenario: 'TRANSFER'
+                initiator: 'PAYER'
+                initiatorType: 'CONSUMER'
+              expiration: '2020-07-15T22:17:28.985-01:00'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /thirdPartyRequests/transactions/{ID}:
+    parameters:
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: >
+        The HTTP request `GET /thirdPartyRequests/transactions/{ID}` is used to get information regarding a transaction request 
+        created or requested earlier. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation 
+        of the transaction request.
+      summary: GetThirdPartyTransactionRequests
+      tags:
+        - thirdPartyRequests
+      operationId: GetThirdPartyTransactionRequests
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: >
+        The callback `PUT /thirdPartyRequests/transactions/{ID}` is used to inform the client of the result of a 
+        previously-requested transaction. The `{ID}` in the URI should contain the `transactionRequestId` that was used for 
+        the creation of the transaction request.
+      summary: Update third party transaction requests
+      tags:
+        - thirdPartyRequests
+      operationId: UpdateThirdPartyTransactionRequests
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Transaction request result returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThirdPartyTransactionRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /thirdPartyRequest/transactions/{ID}/error:
+    put:
+      description: >
+        If the server is unable to find the transaction request, or another processing error occurs, 
+        the error callback `PUT /thirdPartyRequest/transactions/{ID}/error` is used. 
+        The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request.
+      summary: Return transaction error
+      tags:
+        - thirdPartyRequests
+      operationId: UpdateThirdPartyTransactionRequestsError
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  #Authorizations
+  /authorizations:
+    post:
+      description: >
+        The HTTP request `POST /authorizations` is used to request the Payer to enter the applicable credentials in the PISP system.
+      summary: Perform PISP authorization
+      tags:
+        - authorizations
+      operationId: AuthorizationsByIDPost
+      parameters:
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Perform authorization
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationsPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  /authorizations/{ID}:
+    put:
+      description: >
+        The callback `PUT /authorizations/{ID}` is used to inform the client of the result of a previously-requested authorization. 
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /authorizations` request.
+      summary: Return authorization result
+      tags:
+        - authorizations
+      operationId: AuthorizationsByIDPut
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Authorization result returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationsIDPutResponse'
+            example:
+              authenticationInfo:
+                authentication: 'U2F'
+                authenticationValue:
+                  pinValue: 'base64(xxx)'
+                  counter: '1'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /authorizations/{ID}/error:
+    put:
+      description: >
+        If the server is unable to find the authorizations request, or another processing error occurs, 
+        the error callback `PUT /authorizations/{ID}/error` is used. 
+        The `{ID}` in the URI should contain the `{ID}` that was used in the `POST /authorizations/{ID}`.
+      summary: Return authorization error
+      tags:
+        - authorizations
+      operationId: AuthorizationsByIDAndError
+      parameters:
+        #Path
+        - $ref: '#/components/parameters/ID'
+        #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+components:
+  schemas:
+    AccountAddress:
+      title: AccountAddress
+      type: string
+      description: Unique routable address which is DFSP specific.
+      pattern: ^([0-9A-Za-z_~\-\.]+[0-9A-Za-z_~\-])$
+      minLength: 1
+      maxLength: 1023
+    AccountId:
+      type: string
+      description: >
+        A long-lived account identifier provided by the DFSP
+        this MUST NOT be Bank Account Number or anything that
+        may expose a User's private bank account information
+    AuthChannelsEnum:
+      title: AuthChannelsEnum
+      type: string
+      enum:
+        - WEB
+        - OTP
+      description: |
+        The channels requested for a ConsentRequest
+        - "WEB" The PISP is requesting the WEB Consent flow 
+        - "OTP" The PISP is requesting the OTP Consent flow
+    AuthenticationType:
+      title: AuthenticationType
+      type: string
+      enum:
+        - OTP
+        - QRCODE
+        - U2F
+      description: |
+        Below are the allowed values for the enumeration AuthenticationType.
+        - OTP - One-time password generated by the Payer FSP.
+        - QRCODE - QR code used as One Time Password.
+        - U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+    AuthScopesEnum:
+      title: AuthScopesEnum
+      type: string
+      enum:
+        - accounts.getBalance
+        - accounts.transfer
+      description: |
+        The scopes requested for a ConsentRequest
+        - "accounts.getBalance" - Get the balance of a given account
+        - "accounts.transfer" - initiate a transfer from an account
+    Counter:
+      title: Counter
+      $ref: '#/components/schemas/Integer'
+      description: Sequential counter used for cloning detection. Present only for U2F authentication.
+    CorrelationId:
+      title: CorrelationId
+      type: string
+      pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+      description: > 
+        Identifier that correlates all messages of the same sequence. 
+        The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to RFC 4122, 
+        that is restricted by a regular expression for interoperability reasons. 
+        An UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+    CredentialTypeEnum:
+      title: CredentialTypeEnum
+      type: string
+      enum:
+        - FIDO
+      description: |
+        The type of the Credential
+        - "FIDO" - A FIDO public/private keypair
+    CredentialStatusEnum:
+      title: CredentialStatus
+      type: string
+      enum:
+        - PENDING
+        - ACTIVE
+      description: |
+        The status of the Credential's creation
+        - "PENDING" - The PISP has requested a challenge, or the challenge has initialized but not yet answered by the PISP
+        - "ACTIVE" - The Credential is valid, and ready to be used by the PISP
+    Currency:
+      title: Currency
+      description: The currency codes is a three-letter alphabetic codes are used as the standard naming representation for currencies.
+      type: string
+      minLength: 3
+      maxLength: 3
+      enum:
+        - AED
+        - AFN
+        - ALL
+        - AMD
+        - ANG
+        - AOA
+        - ARS
+        - AUD
+        - AWG
+        - AZN
+        - BAM
+        - BBD
+        - BDT
+        - BGN
+        - BHD
+        - BIF
+        - BMD
+        - BND
+        - BOB
+        - BRL
+        - BSD
+        - BTN
+        - BWP
+        - BYN
+        - BZD
+        - CAD
+        - CDF
+        - CHF
+        - CLP
+        - CNY
+        - COP
+        - CRC
+        - CUC
+        - CUP
+        - CVE
+        - CZK
+        - DJF
+        - DKK
+        - DOP
+        - DZD
+        - EGP
+        - ERN
+        - ETB
+        - EUR
+        - FJD
+        - FKP
+        - GBP
+        - GEL
+        - GGP
+        - GHS
+        - GIP
+        - GMD
+        - GNF
+        - GTQ
+        - GYD
+        - HKD
+        - HNL
+        - HRK
+        - HTG
+        - HUF
+        - IDR
+        - ILS
+        - IMP
+        - INR
+        - IQD
+        - IRR
+        - ISK
+        - JEP
+        - JMD
+        - JOD
+        - JPY
+        - KES
+        - KGS
+        - KHR
+        - KMF
+        - KPW
+        - KRW
+        - KWD
+        - KYD
+        - KZT
+        - LAK
+        - LBP
+        - LKR
+        - LRD
+        - LSL
+        - LYD
+        - MAD
+        - MDL
+        - MGA
+        - MKD
+        - MMK
+        - MNT
+        - MOP
+        - MRO
+        - MUR
+        - MVR
+        - MWK
+        - MXN
+        - MYR
+        - MZN
+        - NAD
+        - NGN
+        - NIO
+        - NOK
+        - NPR
+        - NZD
+        - OMR
+        - PAB
+        - PEN
+        - PGK
+        - PHP
+        - PKR
+        - PLN
+        - PYG
+        - QAR
+        - RON
+        - RSD
+        - RUB
+        - RWF
+        - SAR
+        - SBD
+        - SCR
+        - SDG
+        - SEK
+        - SGD
+        - SHP
+        - SLL
+        - SOS
+        - SPL
+        - SRD
+        - STD
+        - SVC
+        - SYP
+        - SZL
+        - THB
+        - TJS
+        - TMT
+        - TND
+        - TOP
+        - TRY
+        - TTD
+        - TVD
+        - TWD
+        - TZS
+        - UAH
+        - UGX
+        - USD
+        - UYU
+        - UZS
+        - VEF
+        - VND
+        - VUV
+        - WST
+        - XAF
+        - XCD
+        - XDR
+        - XOF
+        - XPF
+        - YER
+        - ZAR
+        - ZMW
+        - ZWD
+    Date:
+      title: Date
+      type: string
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: >
+        The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+        This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. 
+        Examples - "1982-05-23", "1987-08-05"
+    DateTime:
+      title: DateTime
+      type: string
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: >
+        The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+        The format is according to ISO 8601, expressed in a combined date, time and time zone format. 
+        A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. 
+        Examples -  "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
+    ErrorCode:
+      title: ErrorCode
+      type: string
+      pattern: ^[1-9]\d{3}$
+      description: >
+        The API data type ErrorCode is a JSON String of four characters, consisting of digits only. 
+        Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, 
+        for example, 1234, where the first number (1 in the example) represents the high-level error category, 
+        the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) 
+        represents the specific error.
+    ErrorDescription:
+      title: ErrorDescription
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Error description string.
+    ExtensionKey:
+      title: ExtensionKey
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
+    Integer:
+      title: Integer
+      type: string
+      pattern: ^[1-9]\d*$
+      description: >
+        The API data type Integer is a JSON String consisting of digits only. 
+        Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: >
+        The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally 
+        not used in a name. Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,''-]{1,128}$". 
+        The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) 
+        (apostrophe (‘), dash (-), comma (,) and space characters ( ). Note -  In some programming languages, 
+        Unicode support must be specifically enabled. For example, if Java is used the flag UNICODE_CHARACTER_CLASS must be enabled 
+        to allow Unicode characters.
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction
+    OtpValue:
+      title: OtpValue
+      type: string
+      pattern: ^\d{3,10}$
+      description: >
+        The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. 
+        Negative numbers are not allowed. One or more leading zeros are allowed.
+    QRCODE:
+      title: QRCODE
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: QR code used as a One Time Password.
+    U2FPIN:
+      title: U2FPIN
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+    U2FPinValue:
+      title: U2FPinValue
+      type: object
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+      properties:
+        pinValue:
+          $ref: '#/components/schemas/U2FPIN'
+          description: U2F challenge-response.
+        counter:
+          $ref: '#/components/schemas/Counter'
+          description: Sequential counter used for cloning detection. Present only for U2F authentication.
+      required:
+        - pinValue
+        - counter
+    RetriesLeft:
+      title: RetriesLeft
+      $ref: '#/components/schemas/Integer'
+      description: >
+        RetriesLeft is the number of retries left before the financial transaction is rejected. 
+        It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before 
+        the financial transaction is rejected.
+
+    #Complex Types
+    Account:
+      title: Account
+      type: object
+      description: Data model for the complex type Account
+      properties:
+        address:
+          $ref: '#/components/schemas/AccountAddress'
+          type: string
+          description: Unique routable address which is DFSP specific.
+        currency:
+          $ref: '#/components/schemas/Currency'
+          type: string
+          description: Currency of the amount.
+        description:
+          $ref: '#/components/schemas/Name'
+          type: string
+          description: The name of the account.
+      required:
+        - address
+        - currency
+        - description
+    AccountList:
+      title: AccountList
+      type: object
+      description: Data model for the complex type AccountList
+      properties:
+        account:
+          type: array
+          items:
+            $ref: '#/components/schemas/Account'
+          minItems: 1
+          maxItems: 32
+          description: Accounts associated with the Party
+      required:
+        - account
+    Amount:
+      title: Amount
+      type: string
+      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      description: >
+        The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons.
+        This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit.
+        It also only allows four digits in the minor currency unit; a negative value is not allowed. 
+        Using more than 18 digits in the major currency unit is not allowed.
+    AmountType:
+      title: AmountType
+      type: string
+      enum:
+        - SEND
+        - RECEIVE
+      description: |
+        Below are the allowed values for the enumeration AmountType.
+
+        - SEND - Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
+
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver 
+        exclusive of any fees.
+    AuthenticationInfo:
+      title: AuthenticationInfo
+      type: object
+      description: Data model for the complex type AuthenticationInfo.
+      properties:
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+          description: Type of authentication.
+        authenticationValue:
+          $ref: '#/components/schemas/AuthenticationValue'
+          description: Authentication value.
+      required:
+        - authentication
+        - authenticationValue
+    AuthenticationValue:
+      title: AuthenticationValue
+      oneOf:
+        - $ref: '#/components/schemas/OtpValue'
+        - $ref: '#/components/schemas/QRCODE'
+        - $ref: '#/components/schemas/U2FPinValue'
+      description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
+    AuthorizationsIDPutResponse:
+      title: AuthorizationsIDPutResponse
+      type: object
+      description: The object sent in the PUT /authorizations/{ID} callback.
+      properties:
+        authenticationInfo:
+          $ref: '#/components/schemas/AuthenticationInfo'
+          description: OTP or QR Code or U2F if entered, otherwise empty.
+        responseType:
+          type: string
+          description: >
+            Enum containing response information; if the customer entered the authentication value, rejected the transaction, or 
+            requested a resend of the authentication value.
+          example: ENTERED
+      required:
+        - responseType
+    AuthorizationsPostRequest:
+      title: AuthorizationsPostRequest
+      type: object
+      description: POST /authorizations Request object
+      properties:
+        authenticationType:
+          $ref: '#/components/schemas/AuthenticationType'
+          description: This value is a valid authentication type from the enumeration AuthenticationType(OTP or QR Code or U2F).
+        retriesLeft:
+          $ref: '#/components/schemas/RetriesLeft'
+          description: >
+            RetriesLeft is the number of retries left before the financial transaction is rejected. 
+            It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before 
+            the financial transaction is rejected.
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: This is the transaction amount that will be withdrawn from the Payer’s account.
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+          description: >
+            Common ID (decided by the Payer FSP) between the FSPs for the future transaction object.
+            The actual transaction will be created as part of a successful transfer process.
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+          description: The transactionRequestID, received from the POST /transactionRequests service earlier in the process.
+        quote:
+          $ref: '#/components/schemas/QuotesIDPutResponse'
+          description: Quotes object
+      required:
+        - authenticationType
+        - retriesLeft
+        - amount
+        - transactionId
+        - transactionRequestId
+        - quote
+    Consent:
+      title: Consent
+      type: object
+      description: Data model for the complex type Consent
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+          description: >
+            Common ID between the PISP and FSP for the Consent object
+            decided by the DFSP who creates the Consent
+
+            This field is REQUIRED for POST /consent
+        requestId:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+          description: >
+            The id of the ConsentRequest that was used to initiate the
+            creation of this Consent
+        participantId:
+          $ref: '#/components/schemas/FspId'
+          description: FSP identifier who issued this Consent
+        initiatorId:
+          allOf:
+            - $ref: '#/components/schemas/FspId'
+          description: PISP identifier who uses this Consent
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Scope'
+        credential:
+          $ref: '#/components/schemas/Credential'
+    ConsentRequest:
+      title: ConsentRequest
+      type: object
+      description: Data model for the complex type ConsentRequest
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+          description: >
+            Common ID between the PISP and FSP for the ConsentRequest object decided by the PISP. 
+            The ID should be reused for resends of the same ConsentRequest. 
+            A new ID should be generated for each new ConsentRequest.
+            This field is REQUIRED for POST /consentRequest
+        initiatorId:
+          allOf:
+            - $ref: '#/components/schemas/FspId'
+          description: PISP identifier who initiated this ConsentRequest
+        accountIds:
+          type: array
+          minItems: 1
+          description: Array of DFSP specific account identifiers, e.g. `dfspa.alice.1234`
+          items:
+            $ref: '#/components/schemas/AccountId'
+        authChannels:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/AuthChannelsEnum'
+          description: A list of requested authorization channels.
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/AuthScopesEnum'
+          description: A list of the requested scopes a PISP would like for the given Consent
+        callbackUri:
+          type: string
+          # TODO: this should be a uri type with a regex to enforce
+          description: >
+            When using the WEB auth channel, `callbackUri` determines where the webpage should 
+            redirect at the end of the WEB login flow. This field is REQUIRED when authChannels
+            contains at least 'WEB'
+        authorizationUri:
+          type: string
+          # TODO: this should be a uri type with a regex to enforce
+          description: >
+            `authorizationUri` tells the PISP where to direct their user to perform the WEB login flow.
+            For OTP based authorization, this will be set to the same value as the `callbackUri`, to inform
+            the PISP to prompt their user for an OTP.
+        authToken:
+          type: string
+          description: |
+            The token issued to the PISP at the end of the auth flow. The PISP must fill out this value. 
+
+            - For the WEB auth flow this token will be passed in along as a URL parameter in the `callbackUri`. 
+
+            - For the OTP auth flow, this will be the otp value delivered to the user directly from the DFSP
+      required:
+        - id
+        - initiatorId
+        - authChannels
+        - scopes
+    Credential:
+      title: Credential
+      type: object
+      description: >
+        A credential used to allow a user to prove their identity and access to an account with a DFSP
+      properties:
+        id:
+          type: string
+          description: The id of a Credential
+        type:
+          $ref: '#/components/schemas/CredentialTypeEnum'
+        status:
+          $ref: '#/components/schemas/CredentialStatusEnum'
+        challenge:
+          $ref: '#/components/schemas/CredentialChallenge'
+        payload:
+          type: string
+          description: Base64 encoded bytes - The public key of the Public/Private keypair
+      required:
+        - id
+        - credentialType
+        - credentialStatus
+    CreateCredential:
+      title: CreateCredential
+      type: object
+      description: >
+        A credential used to allow a user to prove their identity and access to an account with a DFSP
+      properties:
+        type:
+          $ref: '#/components/schemas/CredentialTypeEnum'
+      required:
+        - credentialType
+    CredentialChallenge:
+      title: CredentialChallenge
+      type: object
+      description: >
+        The challenge issued by a DFSP that must be answered by the PISP
+      properties:
+        payload:
+          type: string
+          description: Base64 encoded binary of the challenge that must be answered by the PISP
+        signature:
+          type: string
+          description: Base64 enoded binary string or result of the payload signed by the PISP using the private key
+      required:
+        - payload
+    ErrorInformation:
+      title: ErrorInformation
+      type: object
+      description: Data model for the complex type ErrorInformation.
+      properties:
+        errorCode:
+          $ref: '#/components/schemas/ErrorCode'
+          description: Specific error number.
+        errorDescription:
+          $ref: '#/components/schemas/ErrorDescription'
+          description: Error description string.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional list of extensions, specific to deployment.
+      required:
+        - errorCode
+        - errorDescription
+    ErrorInformationObject:
+      title: ErrorInformationObject
+      type: object
+      description: Data model for the complex type object that contains ErrorInformation.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+      required:
+        - errorInformation
+    ErrorInformationResponse:
+      title: ErrorInformationResponse
+      type: object
+      description: >
+        Data model for the complex type object that contains an optional element 
+        ErrorInformation used along with 4xx and 5xx responses.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+    Extension:
+      title: Extension
+      type: object
+      description: Data model for the complex type Extension
+      properties:
+        key:
+          $ref: '#/components/schemas/ExtensionKey'
+          description: Extension key.
+        value:
+          $ref: '#/components/schemas/ExtensionValue'
+          description: Extension value.
+      required:
+        - key
+        - value
+    ExtensionList:
+      title: ExtensionList
+      type: object
+      description: Data model for the complex type ExtensionList
+      properties:
+        extension:
+          type: array
+          items:
+            $ref: '#/components/schemas/Extension'
+          minItems: 1
+          maxItems: 16
+          description: Number of Extension elements
+      required:
+        - extension
+    GeoCode:
+      title: GeoCode
+      type: object
+      description: >
+        Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
+      properties:
+        latitude:
+          type: string
+          description: Latitude of the Party.
+          example: '+45.4215'
+        longitude:
+          type: string
+          description: Longitude of the Party.
+          example: '+75.6972'
+      required:
+        - latitude
+        - longitude
+    Money:
+      title: Money
+      type: object
+      description: Data model for the complex type Money.
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+      required:
+        - currency
+        - amount
+    Party:
+      title: Party
+      type: object
+      description: Data model for the complex type Party.
+      properties:
+        accounts:
+          $ref: '#/components/schemas/AccountList'
+          description: List of accounts associated with the party containing and DFSP routable address, currency identifier and description.
+        partyIdInfo:
+          $ref: '#/components/schemas/PartyIdInfo'
+          description: Party Id type, id, sub ID or type, and FSP Id.
+        merchantClassificationCode:
+          type: string
+          description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+          example: 4321
+        name:
+          type: string
+          description: Display name of the Party, could be a real name or a nick name.
+          example: Henrik Karlsson
+        personalInfo:
+          $ref: '#/components/schemas/PartyPersonalInfo'
+          description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
+      required:
+        - partyIdInfo
+    PartyComplexName:
+      title: PartyComplexName
+      type: object
+      description: Data model for the complex type PartyComplexName.
+      properties:
+        firstName:
+          type: string
+          description: Party’s first name.
+          example: Henrik
+        middleName:
+          type: string
+          description: Party’s middle name.
+          example: Johannes
+        lastName:
+          type: string
+          description: Party’s last name.
+          example: Karlsson
+    PartyIdInfo:
+      title: PartyIdInfo
+      type: object
+      description: Data model for the complex type PartyIdInfo.
+      properties:
+        partyIdType:
+          type: string
+          description: Type of the identifier.
+          example: PERSONAL_ID
+        partyIdentifier:
+          type: string
+          description: An identifier for the Party.
+          example: 16135551212
+        partySubIdOrType:
+          type: string
+          description: A sub-identifier or sub-type for the Party.
+          example: DRIVING_LICENSE
+        fspId:
+          type: string
+          description: FSP ID (if known).
+          example: 1234
+      required:
+        - partyIdType
+        - partyIdentifier
+    PartyPersonalInfo:
+      title: PartyPersonalInfo
+      type: object
+      description: Data model for the complex type PartyPersonalInfo.
+      properties:
+        complexName:
+          $ref: '#/components/schemas/PartyComplexName'
+          description: First, middle and last name for the Party.
+        dateOfBirth:
+          type: string
+          description: Date of birth for the Party.
+          example: '1966-06-16'
+    PartiesTypeIDPutResponse:
+      title: PartiesTypeIDPutResponse
+      type: object
+      description: The object sent in the PUT /parties/{Type}/{ID} callback.
+      properties:
+        party:
+          $ref: '#/components/schemas/Party'
+          description: Information regarding the requested Party.
+      required:
+        - party
+    QuotesIDPutResponse:
+      title: QuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /quotes/{ID} callback.
+      properties:
+        transferAmount:
+          description: The amount of money that the Payee FSP should receive.
+          type: object
+          $ref: '#/components/schemas/Money'
+        payeeReceiveAmount:
+          description: > 
+            The amount of Money that the Payee should receive in the end-to-end transaction. 
+            Optional as the Payee FSP might not want to disclose any optional Payee fees.
+          type: object
+          $ref: '#/components/schemas/Money'
+        payeeFspFee:
+          description: Payee FSP’s part of the transaction fee.
+          type: object
+          $ref: '#/components/schemas/Money'
+        payeeFspCommission:
+          description: Transaction commission from the Payee FSP.
+          type: object
+          $ref: '#/components/schemas/Money'
+        expiration:
+          type: string
+          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
+          example: '2016-05-24T08:38:08.699-04:00'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+          description: Longitude and Latitude of the Payee. Can be used to detect fraud.
+        ilpPacket:
+          type: string
+          description: The ILP Packet that must be attached to the transfer by the Payer.
+          example: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA”
+        condition:
+          type: string
+          description: The condition that must be attached to the transfer by the Payer.
+          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+        - transferAmount
+        - expiration
+        - ilpPacket
+        - condition
+    Refund:
+      title: Refund
+      type: object
+      description: Data model for the complex type Refund.
+      properties:
+        originalTransactionId:
+          type: string
+          description: Reference to the original transaction ID that is requested to be refunded.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        refundReason:
+          type: string
+          description: Free text indicating the reason for the refund.
+          example: Free text indicating reason for the refund.
+      required:
+        - originalTransactionId
+    Scope:
+      title: Scope
+      type: object
+      description: Scope + Account Identifier mapping for a Consent
+      properties:
+        scope:
+          $ref: '#/components/schemas/AuthScopesEnum'
+        accountId:
+          $ref: '#/components/schemas/AccountId'
+      required:
+        - scope
+        - accountId
+    ThirdPartyTransactionRequest:
+      title: ThirdPartyTransactionRequest
+      type: object
+      description: The object sent in the POST /thirdPartyRequests/transactions request.
+      properties:
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+          description: >
+            Common ID between the FSPs for the transaction request object. 
+            The ID should be reused for resends of the same transaction request.
+            A new ID should be generated for each new transaction request.
+        sourceAccountId:
+          $ref: '#/components/schemas/AccountId'
+          description: DFSP specific account identifiers, e.g. `dfspa.alice.1234`
+        consentId:
+          allOf:
+            - $ref: '#/components/schemas/CorrelationId'
+          description: >
+            Common ID between the PISP and FSP for the Consent object
+            This tells DFSP and auth-service which constent allows the PISP to initiate transaction.
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        payer:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payer in the proposed financial transaction.
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+          description: SEND for sendAmount, RECEIVE for receiveAmount.
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: Requested amount to be transferred from the Payer to Payee.
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+          description: Type of transaction.
+        expiration:
+          type: string
+          description: >
+            Date and time until when the transaction request is valid. 
+            It can be set to get a quick failure in case the peer FSP takes too long to respond.
+          example: '2016-05-24T08:38:08.699-04:00'
+      required:
+        - transactionRequestId
+        - sourceAccountId
+        - consentId
+        - payee
+        - payer
+        - amountType
+        - amount
+        - transactionType
+        - expiration
+    TransactionType:
+      title: TransactionType
+      type: object
+      description: Data model for the complex type TransactionType.
+      properties:
+        scenario:
+          type: string
+          description: Deposit, withdrawal, refund, …
+          example: DEPOSIT
+        subScenario:
+          type: string
+          description: Possible sub-scenario, defined locally within the scheme.
+          example: Locally defined sub-scenario.
+        initiator:
+          type: string
+          description: Who is initiating the transaction - Payer or Payee.
+          example: PAYEE
+        initiatorType:
+          type: string
+          description: Consumer, agent, business, …
+          example: CONSUMER
+        refundInfo:
+          $ref: '#/components/schemas/Refund'
+          description: Extra information specific to a refund scenario. Should only be populated if scenario is REFUND.
+        balanceOfPayments:
+          type: string
+          description: Balance of Payments code.
+          example: 123
+      required:
+        - scenario
+        - initiator
+        - initiatorType
+
+  responses:
+    200:
+      description: OK
+    202:
+      description: Accepted
+    400:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    401:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    403:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    404:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    405:
+      description: Method Not Allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    406:
+      description: Not Acceptable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    501:
+      description: Not Implemented
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    503:
+      description: Service Unavailable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+
+  parameters:
+    #Header parameters
+    Accept:
+      name: Accept
+      in: header
+      required: true
+      schema:
+        type: string
+      description: The `Accept` header field indicates the version of the API the client would like the server to use.
+    Content-Length:
+      name: Content-Length
+      in: header
+      required: false
+      schema:
+        type: integer
+      description: > 
+        The `Content-Length` header field indicates the anticipated size of the payload body. 
+        Only sent if there is a body.Note-The API supports a maximum size of 5242880 bytes (5 Megabytes).
+    Content-Type:
+      name: Content-Type
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `Content-Type` header indicates the specific version of the API used to send the payload body.
+    Date:
+      name: Date
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `Date` header field indicates the date when the request was sent.
+    X-Forwarded-For:
+      name: X-Forwarded-For
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >
+        The `X-Forwarded-For` header field is an unofficially accepted standard used for informational purposes of the originating 
+        client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple `X-Forwarded-For` values should
+        be expected and supported by implementers of the API.
+        Note-An alternative to `X-Forwarded-For` is defined in [RFC 7239](https://tools.ietf.org/html/rfc7239). 
+        However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
+    FSPIOP-Source:
+      name: FSPIOP-Source
+      in: header
+      schema:
+        type: string
+      required: true
+      description: > 
+        The `FSPIOP-Source` header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. 
+        The field should be set by the original sender of the request. 
+        Required for routing and signature verification (see header field `FSPIOP-Signature`).
+    FSPIOP-Destination:
+      name: FSPIOP-Destination
+      in: header
+      schema:
+        type: string
+      required: false
+      description: > 
+        The `FSPIOP-Destination` header field is a non-HTTP standard field used by the API 
+        for HTTP header based routing of requests and responses to the destination. 
+        The field should be set by the original sender of the request (if known), so that any entities between the client and 
+        the server do not need to parse the payload for routing purposes.
+    FSPIOP-Encryption:
+      name: FSPIOP-Encryption
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >  
+        The `FSPIOP-Encryption` header field is a non-HTTP standard field used by the API 
+        for applying end-to-end encryption of the request.
+    FSPIOP-Signature:
+      name: FSPIOP-Signature
+      in: header
+      schema:
+        type: string
+      required: false
+      description: > 
+        The `FSPIOP-Signature` header field is a non-HTTP standard field used by the API 
+        for applying an end-to-end request signature.
+    FSPIOP-URI:
+      name: FSPIOP-URI
+      in: header
+      schema:
+        type: string
+      required: false
+      description: > 
+        The `FSPIOP-URI` header field is a non-HTTP standard field used by the API for signature verification, 
+        should contain the service URI. Required if signature verification is used, for more information, 
+        see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+    FSPIOP-HTTP-Method:
+      name: FSPIOP-HTTP-Method
+      in: header
+      schema:
+        type: string
+      required: false
+      description: > 
+        The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by the API for signature verification, 
+        should contain the service HTTP method. Required if signature verification is used, for more information, 
+        see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+    #Path parameters
+    ID:
+      name: ID
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The identifier value.
+    Type:
+      name: Type
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+    SubId:
+      name: SubId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: > 
+        A sub-identifier of the party identifier, or a sub-type of the party identifier's type. 
+        For example, `PASSPORT`, `DRIVING_LICENSE`.


### PR DESCRIPTION
`#316 : Added following API definitions , please review it.`

**New endpoints**

1. consentRequest (**3**) : `POST /consentRequests, PUT /consentRequests/{ID} and PUT /consentRequests/{ID}/error`
2. consent (**4**):  `POST /consents, GET /consents/{ID} ,PUT /consents/{ID}  and POST /consents/{ID}/createCredential`
3. thirdPartyRequests (**4**): `POST /thirdPartyRequests/transactions, GET /thirdPartyRequests/transactions/{ID}, PUT /thirdPartyRequests/transactions/{ID} and PUT /thirdPartyRequest/transactions/{ID}/error`

**Existing endpoints from Mojaloop API**

1. authorizations (**3**) : `POST /authorizations, PUT /authorizations/{ID}  and PUT /authorizations/{ID}/error`
2. parties (**6**): `GET /parties/{Type}/{ID}, PUT /parties/{Type}/{ID}, PUT /parties/{Type}/{ID}/error, GET /parties/{Type}/{ID}/{SubId},  PUT /parties/{Type}/{ID}/{SubId} and PUT /parties/{Type}/{ID}/{SubId}/error`