### PR TITLE
Removed test command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ WORKDIR /opt/thirdparty-api-adapter
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
-    && npm install -g node-gyp 
+    && npm install -g node-gyp
 
 COPY package.json package-lock.json* /opt/thirdparty-api-adapter/
 RUN npm ci
 
-# Create empty log file & 
+# Create empty log file &
 RUN mkdir ./logs && touch ./logs/combined.log
 
 # link stdout to the application log file
@@ -19,7 +19,7 @@ RUN ln -sf /dev/stdout ./logs/combined.log
 # check in .dockerignore what is skipped during copy
 COPY . .
 
-# USER node 
+# USER node
 # copy bundle
 # COPY --chown=node --from=builder /opt/thirdparty-api-adapter/ .
 
@@ -27,6 +27,5 @@ COPY . .
 RUN apk del build-dependencies
 
 # RUN npm prune --production
-RUN npm run test:unit
 EXPOSE 3008
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
`RUN npm run test:unit` and the subsequent tests are causing some unknown error in circleci that I've been unable to diagnose. unit test coverage is covered in the `test-unit` job in circleci so this shouldn't be needed in `Dockerfile`.