### PR TITLE
feat: Add PUT /thirdpartyRequests/transactions/{ID} endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1924,9 +1924,9 @@
       "optional": true
     },
     "@mojaloop/api-snippets": {
-      "version": "11.0.18",
-      "resolved": "https://registry.npmjs.org/@mojaloop/api-snippets/-/api-snippets-11.0.18.tgz",
-      "integrity": "sha512-jfrjpuodHXvBAeNc3WrFykfuC6IZr0diHIOhr1cKE7SEfTfT3eApDT7cJfTZRDXkhUfe5pBggCR/BrcR9/yjhg==",
+      "version": "11.0.20",
+      "resolved": "https://registry.npmjs.org/@mojaloop/api-snippets/-/api-snippets-11.0.20.tgz",
+      "integrity": "sha512-z+u6l/xkfJAb4GShqPoshGgZQ42fhzJ6/qRnW80RR44QT6AnM4Nfc3gNO+OTkSwHwBBtdNF8GbRwXUBRBMiyNA==",
       "requires": {
         "commander": "^2.19.0",
         "js-yaml": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",
     "@hapi/vision": "^6.0.0",
-    "@mojaloop/api-snippets": "11.0.18",
+    "@mojaloop/api-snippets": "11.0.20",
     "@mojaloop/central-services-error-handling": "10.6.0",
     "@mojaloop/central-services-health": "10.6.0",
     "@mojaloop/central-services-logger": "10.6.0",

--- a/src/domain/thirdpartyRequests/transactions.ts
+++ b/src/domain/thirdpartyRequests/transactions.ts
@@ -70,7 +70,7 @@ async function forwardTransactionRequest (
   const fspiopDest: string = headers[Enum.Http.Headers.FSPIOP.DESTINATION]
   const payloadLocal = payload || { transactionRequestId: params.ID }
   const transactionRequestId: string =
-    (payload && isItCreateRequest(payload)) ? payload.transactionRequestId : params.ID
+    (payload && isCreateRequest(payload)) ? payload.transactionRequestId : params.ID
   try {
     const fullUrl = await Util.Endpoints.getEndpointAndRender(
       Config.ENDPOINT_SERVICE_URL,
@@ -232,7 +232,7 @@ async function forwardTransactionRequestNotification (
 }
 
 type CreateOrUpdateReq = types.ThirdPartyTransactionRequest | types.UpdateThirdPartyTransactionRequest
-function isItCreateRequest (request: CreateOrUpdateReq): request is types.ThirdPartyTransactionRequest {
+function isCreateRequest (request: CreateOrUpdateReq): request is types.ThirdPartyTransactionRequest {
   if ((request as types.ThirdPartyTransactionRequest).transactionRequestId) {
     return true
   }
@@ -242,5 +242,6 @@ function isItCreateRequest (request: CreateOrUpdateReq): request is types.ThirdP
 export {
   forwardTransactionRequest,
   forwardTransactionRequestError,
-  forwardTransactionRequestNotification
+  forwardTransactionRequestNotification,
+  isCreateRequest //for testing
 }

--- a/src/interface/api-template.yaml
+++ b/src/interface/api-template.yaml
@@ -142,6 +142,18 @@ paths:
         503:
           $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/503'
   /thirdpartyRequests/transactions/{ID}:
+    parameters:
+      #Path
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/ID.yaml'
+      #Headers
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Date.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/X-Forwarded-For.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Source.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Destination.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Encryption.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Signature.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-URI.yaml'
+      - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-HTTP-Method.yaml'
     get:
       tags:
         - thirdpartyRequests
@@ -151,21 +163,51 @@ paths:
       description: |
         The HTTP request `GET /thirdpartyRequests/transactions/{ID}` is used to request the retrieval of a third party transaction.
       parameters:
-        #Path
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/ID.yaml'
         #Headers
         - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Accept.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Date.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/X-Forwarded-For.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Source.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Destination.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Encryption.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-Signature.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-URI.yaml'
-        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/FSPIOP-HTTP-Method.yaml'
       responses:
         202:
           $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/202'
+        400:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/400'
+        401:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/401'
+        403:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/403'
+        404:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/404'
+        405:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/405'
+        406:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/406'
+        501:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/501'
+        503:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/503'
+    put:
+      tags:
+        - thirdpartyRequests
+        - sampled
+      operationId: UpdateThirdPartyTransactionRequests
+      summary: UpdateThirdPartyTransactionRequests
+      description: |
+        The HTTP request `PUT /thirdpartyRequests/transactions/{ID}` is used to inform the client about 
+        status of a previously requested thirdparty transaction.
+
+        Switch(Thirdparty API Adapter) -> PISP
+      parameters:
+        #Headers
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Content-Length.yaml'
+        - $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/parameters/Content-Type.yaml'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../../node_modules/@mojaloop/api-snippets/thirdparty/openapi3/schemas/ThirdpartyRequestsTransactionsIDPutResponse.yaml'
+      responses:
+        200:
+          $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/200'
         400:
           $ref: '../../node_modules/@mojaloop/api-snippets/v1.0/openapi3/responses/index.yaml#/400'
         401:

--- a/src/interface/api.yaml
+++ b/src/interface/api.yaml
@@ -163,14 +163,14 @@ paths:
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: Transaction request to be created.
         required: true
@@ -225,6 +225,91 @@ paths:
         '503':
           $ref: '#/paths/~1health/get/responses/503'
   '/thirdpartyRequests/transactions/{ID}':
+    parameters:
+      - name: ID
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The identifier value.
+      - name: Date
+        in: header
+        schema:
+          type: string
+        required: true
+        description: The `Date` header field indicates the date when the request was sent.
+      - name: X-Forwarded-For
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `X-Forwarded-For` header field is an unofficially accepted standard used
+          for informational purposes of the originating client IP address, as a
+          request might pass multiple proxies, firewalls, and so on. Multiple
+          `X-Forwarded-For` values should be expected and supported by implementers
+          of the API.
+          **Note:** An alternative to `X-Forwarded-For` is defined in
+          [RFC 7239](https://tools.ietf.org/html/rfc7239).
+          However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
+      - name: FSPIOP-Source
+        in: header
+        schema:
+          type: string
+        required: true
+        description: |
+          The `FSPIOP-Source` header field is a non-HTTP standard field
+          used by the API for identifying the sender of the HTTP request.
+          The field should be set by the original sender of the request.
+          Required for routing and signature verification
+          (see header field `FSPIOP-Signature`).
+      - name: FSPIOP-Destination
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `FSPIOP-Destination` header field is a non-HTTP standard field used by
+          the API for HTTP header based routing of requests and responses to the
+          destination. The field should be set by the original sender of the request
+          (if known), so that any entities between the client and the server do not
+          need to parse the payload for routing purposes.
+      - name: FSPIOP-Encryption
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `FSPIOP-Encryption` header field is a non-HTTP standard field used by
+          the API for applying end-to-end encryption of the request.
+      - name: FSPIOP-Signature
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `FSPIOP-Signature` header field is a non-HTTP standard field used by the
+          API for applying an end-to-end request signature.
+      - name: FSPIOP-URI
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `FSPIOP-URI` header field is a non-HTTP standard field used by the API
+          for signature verification, should contain the service URI. Required if
+          signature verification is used, for more information, see
+          [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+      - name: FSPIOP-HTTP-Method
+        in: header
+        schema:
+          type: string
+        required: false
+        description: |
+          The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by
+          the API for signature verification, should contain the service HTTP method.
+          Required if signature verification is used, for more information, see
+          [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
     get:
       tags:
         - thirdpartyRequests
@@ -234,19 +319,72 @@ paths:
       description: |
         The HTTP request `GET /thirdpartyRequests/transactions/{ID}` is used to request the retrieval of a third party transaction.
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/0'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
       responses:
         '202':
           $ref: '#/paths/~1consents/post/responses/202'
+        '400':
+          $ref: '#/paths/~1health/get/responses/400'
+        '401':
+          $ref: '#/paths/~1health/get/responses/401'
+        '403':
+          $ref: '#/paths/~1health/get/responses/403'
+        '404':
+          $ref: '#/paths/~1health/get/responses/404'
+        '405':
+          $ref: '#/paths/~1health/get/responses/405'
+        '406':
+          $ref: '#/paths/~1health/get/responses/406'
+        '501':
+          $ref: '#/paths/~1health/get/responses/501'
+        '503':
+          $ref: '#/paths/~1health/get/responses/503'
+    put:
+      tags:
+        - thirdpartyRequests
+        - sampled
+      operationId: UpdateThirdPartyTransactionRequests
+      summary: UpdateThirdPartyTransactionRequests
+      description: |
+        The HTTP request `PUT /thirdpartyRequests/transactions/{ID}` is used to inform the client about 
+        status of a previously requested thirdparty transaction.
+
+        Switch(Thirdparty API Adapter) -> PISP
+      parameters:
+        - $ref: '#/paths/~1consents/post/parameters/1'
+        - $ref: '#/paths/~1consents/post/parameters/2'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: ThirdpartyRequestsTransactionsIDPutResponse
+              type: object
+              description: 'The object sent in the PUT /thirdPartyRequests/transactions/{ID} request.'
+              properties:
+                transactionId:
+                  $ref: '#/components/schemas/ThirdpartyTransactionRequest/properties/consentId/allOf/0'
+                transactionRequestState:
+                  title: TransactionRequestState
+                  type: string
+                  enum:
+                    - RECEIVED
+                    - PENDING
+                    - ACCEPTED
+                    - REJECTED
+                  description: |
+                    Below are the allowed values for the enumeration.
+                    - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
+                    - PENDING - Payer FSP has sent the transaction request to the Payer.
+                    - ACCEPTED - Payer has approved the transaction.
+                    - REJECTED - Payer has rejected the transaction."
+                  example: RECEIVED
+              required:
+                - transactionId
+                - transactionRequestState
+      responses:
+        '200':
+          $ref: '#/paths/~1health/get/responses/200'
         '400':
           $ref: '#/paths/~1health/get/responses/400'
         '401':
@@ -270,18 +408,18 @@ paths:
         - sampled
       operationId: ThirdpartyTransactionRequestsError
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: Details of the error returned.
         required: true
@@ -385,18 +523,18 @@ paths:
       description: |
         The HTTP request `POST /thirdpartyRequests/transactions/{id}/authorizations` is used by the DFSP to verify a third party authorization.
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: The thirdparty authorization details to verify
         required: true
@@ -439,17 +577,17 @@ paths:
         The HTTP request `PUT /thirdpartyRequests/transactions/{id}/authorizations` is used by the auth-service to update a thirdparty authorization after successful validation.
         For an unsuccessful authorization result, the `PUT /thirdpartyRequests/transactions/{id}/authorizations/error` will be called by the auth-service, instead of this endpoint.
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: The thirdparty authorization details to update
         required: true
@@ -495,14 +633,14 @@ paths:
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: The consentRequest to create
         required: true
@@ -591,18 +729,18 @@ paths:
         PISP updates the consentRequest to include authorization token from their user,
         which the DFSP is to then verify.
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         required: true
         content:
@@ -894,84 +1032,14 @@ paths:
           description: |
             The `Content-Type` header indicates the specific version of the API used
             to send the payload body.
-        - name: Date
-          in: header
-          schema:
-            type: string
-          required: true
-          description: The `Date` header field indicates the date when the request was sent.
-        - name: X-Forwarded-For
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `X-Forwarded-For` header field is an unofficially accepted standard used
-            for informational purposes of the originating client IP address, as a
-            request might pass multiple proxies, firewalls, and so on. Multiple
-            `X-Forwarded-For` values should be expected and supported by implementers
-            of the API.
-            **Note:** An alternative to `X-Forwarded-For` is defined in
-            [RFC 7239](https://tools.ietf.org/html/rfc7239).
-            However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
-        - name: FSPIOP-Source
-          in: header
-          schema:
-            type: string
-          required: true
-          description: |
-            The `FSPIOP-Source` header field is a non-HTTP standard field
-            used by the API for identifying the sender of the HTTP request.
-            The field should be set by the original sender of the request.
-            Required for routing and signature verification
-            (see header field `FSPIOP-Signature`).
-        - name: FSPIOP-Destination
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `FSPIOP-Destination` header field is a non-HTTP standard field used by
-            the API for HTTP header based routing of requests and responses to the
-            destination. The field should be set by the original sender of the request
-            (if known), so that any entities between the client and the server do not
-            need to parse the payload for routing purposes.
-        - name: FSPIOP-Encryption
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `FSPIOP-Encryption` header field is a non-HTTP standard field used by
-            the API for applying end-to-end encryption of the request.
-        - name: FSPIOP-Signature
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `FSPIOP-Signature` header field is a non-HTTP standard field used by the
-            API for applying an end-to-end request signature.
-        - name: FSPIOP-URI
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `FSPIOP-URI` header field is a non-HTTP standard field used by the API
-            for signature verification, should contain the service URI. Required if
-            signature verification is used, for more information, see
-            [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
-        - name: FSPIOP-HTTP-Method
-          in: header
-          schema:
-            type: string
-          required: false
-          description: |
-            The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by
-            the API for signature verification, should contain the service HTTP method.
-            Required if signature verification is used, for more information, see
-            [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       responses:
         '202':
           description: Accepted
@@ -1003,18 +1071,18 @@ paths:
 
         PISP -> Switch
       parameters:
-        - $ref: '#/paths/~1consents~1%7BID%7D/put/parameters/0'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/1'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       requestBody:
         description: GenerateChallengeRequest Body
         required: true
@@ -1281,21 +1349,16 @@ paths:
                     - scopes
                     - credential
       parameters:
-        - name: ID
-          in: path
-          required: true
-          schema:
-            type: string
-          description: The identifier value.
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/0'
         - $ref: '#/paths/~1consents/post/parameters/2'
-        - $ref: '#/paths/~1consents/post/parameters/3'
-        - $ref: '#/paths/~1consents/post/parameters/4'
-        - $ref: '#/paths/~1consents/post/parameters/5'
-        - $ref: '#/paths/~1consents/post/parameters/6'
-        - $ref: '#/paths/~1consents/post/parameters/7'
-        - $ref: '#/paths/~1consents/post/parameters/8'
-        - $ref: '#/paths/~1consents/post/parameters/9'
-        - $ref: '#/paths/~1consents/post/parameters/10'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/1'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/2'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/3'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/4'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/5'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/6'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/7'
+        - $ref: '#/paths/~1thirdpartyRequests~1transactions~1%7BID%7D/parameters/8'
       responses:
         '200':
           $ref: '#/paths/~1health/get/responses/200'

--- a/src/interface/types.ts
+++ b/src/interface/types.ts
@@ -102,6 +102,22 @@ export interface ThirdPartyTransactionRequest {
   expiration: string;
 }
 /**
+* Transaction request state
+*/
+export enum TransactionRequestState {
+  RECEIVED = 'RECEIVED',
+  PENDING = 'PENDING',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED'
+}
+/**
+* This interface used for update transaction requests
+*/
+export interface UpdateThirdPartyTransactionRequest {
+  transactionId: TransactionRequestState;
+  transactionRequestState: string;
+}
+/**
 * This interface used for common errors
 */
 export interface ErrorInformation {

--- a/src/interface/types.ts
+++ b/src/interface/types.ts
@@ -114,8 +114,8 @@ export enum TransactionRequestState {
 * This interface used for update transaction requests
 */
 export interface UpdateThirdPartyTransactionRequest {
-  transactionId: TransactionRequestState;
-  transactionRequestState: string;
+  transactionId: string;
+  transactionRequestState: TransactionRequestState;
 }
 /**
 * This interface used for common errors

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -58,6 +58,14 @@ export default {
       ['success']
     ]
   ),
+  UpdateThirdPartyTransactionRequests: wrapWithHistogram(
+    ThirdpartyTransactionsId.put,
+    [
+      'thirdpartyRequests_transactions_put',
+      'Put thirdpartyRequests transactions request',
+      ['success']
+    ]
+  ),
   ThirdpartyTransactionRequestsError: wrapWithHistogram(
     ThirdpartyTransactionsIdError.put,
     [

--- a/test/features/transactionRequests.feature
+++ b/test/features/transactionRequests.feature
@@ -20,6 +20,11 @@ Scenario: GetThirdpartyTransactionRequests
   When I send a 'GetThirdpartyTransactionRequests' request
   Then I get a response with a status code of '202'
 
+Scenario: UpdateThirdPartyTransactionRequests
+  Given thirdparty-api-adapter server
+  When I send a 'UpdateThirdPartyTransactionRequests' request
+  Then I get a response with a status code of '200'
+
 Scenario: ThirdpartyTransactionRequestsError
   Given thirdparty-api-adapter server
   When I send a 'ThirdpartyTransactionRequestsError' request

--- a/test/step-definitions/transactionRequests.step.ts
+++ b/test/step-definitions/transactionRequests.step.ts
@@ -202,6 +202,46 @@ defineFeature(feature, (test): void => {
     })
   })
 
+  test('UpdateThirdPartyTransactionRequests', ({ given, when, then }): void => {
+    const reqHeaders = {
+      ...mockData.updateTransactionRequest.headers,
+      date: (new Date()).toISOString(),
+      accept: 'application/json'
+    }
+    const request = {
+      method: 'PUT',
+      url: '/thirdpartyRequests/transactions/b37605f7-bcd9-408b-9291-6c554aa4c802',
+      headers: reqHeaders,
+      payload: mockData.updateTransactionRequest.payload
+    }
+    given('thirdparty-api-adapter server', async (): Promise<Server> => {
+      server = await ThirdPartyAPIAdapterService.run(Config)
+      return server
+    })
+
+    when('I send a \'UpdateThirdPartyTransactionRequests\' request', async (): Promise<ServerInjectResponse> => {
+      mockForwardTransactionRequest.mockResolvedValueOnce()
+      response = await server.inject(request)
+      return response
+    })
+
+    then('I get a response with a status code of \'200\'', (): void => {
+      const expected = [
+        '/thirdpartyRequests/transactions/{{ID}}',
+        'TP_CB_URL_TRANSACTION_REQUEST_PUT',
+        expect.objectContaining(request.headers),
+        'PUT',
+        { "ID": "b37605f7-bcd9-408b-9291-6c554aa4c802" },
+        request.payload,
+        expect.any(Object)
+      ]
+
+      expect(response.statusCode).toBe(200)
+      expect(response.result).toBeNull()
+      expect(mockForwardTransactionRequest).toHaveBeenCalledWith(...expected)
+    })
+  })
+
   test('ThirdpartyTransactionRequestsError', ({ given, when, then }): void => {
     const reqHeaders = {
       ...mockData.transactionRequest.headers,

--- a/test/unit/data/mockData.json
+++ b/test/unit/data/mockData.json
@@ -50,6 +50,19 @@
     "params": {"ID": "b37605f7-bcd9-408b-9291-6c554aa4c802"},
     "payload": {}
   },
+  "updateTransactionRequest": {
+    "headers": {
+      "fspiop-source": "dfspA",
+      "fspiop-destination": "pispA"
+    },
+    "params": {
+      "ID": "b37605f7-bcd9-408b-9291-6c554aa4c802"
+    },
+    "payload": {
+      "transactionId": "8e34f91d-d078-4077-8263-2c047876fcf6",
+      "transactionRequestState": "RECEIVED"
+    }
+  },
   "internalConfig": {
     "options": {
       "mode": 2,

--- a/test/unit/domain/thirdpartyRequests/transactions.test.ts
+++ b/test/unit/domain/thirdpartyRequests/transactions.test.ts
@@ -280,6 +280,11 @@ describe('domain /thirdpartyRequests/transactions', (): void => {
       expect(mockSendRequest).toHaveBeenCalledWith(...sendRequestExpectedPostTransactionRequest)
       expect(mockSendRequest).toHaveBeenCalledWith(...sendRequestErrExpected)
     })
+
+    it('verify isCreateRequest', async (): Promise<void> => {
+      expect(Transactions.isCreateRequest(mockData.transactionRequest.payload)).toBeTruthy();
+      expect(Transactions.isCreateRequest(mockData.updateTransactionRequest.payload)).toBeFalsy();
+    })
   })
 
   describe('forwardTransactionRequestNotification', (): void => {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -156,6 +156,34 @@ describe('index', (): void => {
       })
     })
 
+    it('PUT', async (): Promise<void> => {
+      mockForwardTransactionRequest.mockResolvedValueOnce()
+      const reqHeaders = Object.assign(mockData.updateTransactionRequest.headers, {
+        date: 'Thu, 23 Jan 2020 10:22:12 GMT',
+        accept: 'application/json'
+      })
+      const request = {
+        method: 'PUT',
+        url: '/thirdpartyRequests/transactions/b37605f7-bcd9-408b-9291-6c554aa4c802',
+        headers: reqHeaders,
+        payload: mockData.updateTransactionRequest.payload
+      }
+
+      const expected = [
+        '/thirdpartyRequests/transactions/{{ID}}',
+        'TP_CB_URL_TRANSACTION_REQUEST_PUT',
+        expect.objectContaining(request.headers),
+        'PUT',
+        { 'ID': 'b37605f7-bcd9-408b-9291-6c554aa4c802' },
+        request.payload,
+        expect.any(Object)
+      ]
+      const response = await server.inject(request)
+
+      expect(response.statusCode).toBe(200)
+      expect(response.result).toBeNull()
+      expect(mockForwardTransactionRequest).toHaveBeenCalledWith(...expected)
+    })
 
     describe('/thirdpartyRequests/transactions/{ID}/error', (): void => {
       beforeAll((): void => {


### PR DESCRIPTION
Closes #[1765](https://github.com/mojaloop/project/issues/1765)

-  Add `PUT /thirdpartyRequests/transactions/{id}` endpoint in thirdparty-api-adapter
- update api-snippets
- handle inbound PUT `/thirdpartyRequests/transactions/{id}` from DFSP